### PR TITLE
Feat/remove checkov and deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.15
 
-# RUN ["/bin/sh", "-c", "apk add --update --no-cache gcc libffi-dev python3-dev musl-dev bash ca-certificates curl git jq openssh findutils cmd:pip3"]
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh findutils"]
 
 COPY ["src", "/src/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh findutils"]
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
 
 COPY ["src", "/src/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM alpine:3.15
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache gcc libffi-dev python3-dev musl-dev bash ca-certificates curl git jq openssh findutils cmd:pip3"]
-
-# RUN ["/bin/sh", "-c", "pip3 install wheel"]
-
-# RUN ["/bin/sh", "-c", "pip3 install checkov"]
+# RUN ["/bin/sh", "-c", "apk add --update --no-cache gcc libffi-dev python3-dev musl-dev bash ca-certificates curl git jq openssh findutils cmd:pip3"]
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh findutils"]
 
 COPY ["src", "/src/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.15
 
 RUN ["/bin/sh", "-c", "apk add --update --no-cache gcc libffi-dev python3-dev musl-dev bash ca-certificates curl git jq openssh findutils cmd:pip3"]
 
-RUN ["/bin/sh", "-c", "pip3 install wheel"]
+# RUN ["/bin/sh", "-c", "pip3 install wheel"]
 
-RUN ["/bin/sh", "-c", "pip3 install checkov"]
+# RUN ["/bin/sh", "-c", "pip3 install checkov"]
 
 COPY ["src", "/src/"]
 


### PR DESCRIPTION
## Description
Removing `checkov` and dependencies from the build to speed up build-time.

## Motivation and Context
So far, `checkov` isn't used in the action but the dependencies - `wheels` in particular - extend the build-time quite a lot.
A customer wants to streamline their pipelines that use this action, so we're removing `checkov` and `wheel` (and some other packages) from this build.

## Breaking Changes
Packages removed from the container:
- gcc
- libffi-dev
- python3-dev
- musl-dev
- pip
- wheel
- checkov
- findutils

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
Referenced the specific (feature-)branch of the action in a separate (private) repository.  
In the repository a `random_pet` is defined.  
The pipeline performs a Terragrunt `init`, `validate`, `plan` and `apply` on the passed [working directory](https://github.com/CloudNation-nl/cn-terragrunt-github-actions/tree/main/examples/working-directory.md).
